### PR TITLE
Support oodle as a doublewrite endpoint or the only endpoint

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -1,4 +1,4 @@
 ---
-owner: grafana
+owner: oodle-ai
 git-repo: helm-charts
 skip-existing: true

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -12,7 +12,7 @@ env:
   CR_VERSION: "1.5.0"
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       changed: ${{ steps.list-changed.outputs.changed }}
       chartpath: ${{ steps.list-changed.outputs.chartpath }}
@@ -22,6 +22,9 @@ jobs:
         with:
           fetch-depth: 0
           path: source
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
 
       - name: Install chart-testing
         uses: helm/chart-testing-action@v2
@@ -65,7 +68,7 @@ jobs:
 
   release:
     needs: [setup]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: needs.setup.outputs.changed == 'true'
     steps:
       - name: Checkout
@@ -84,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: grafana/helm-charts
+          repository: oodle-ai/helm-charts
           path: helm-charts
           token: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
 
@@ -114,6 +117,10 @@ jobs:
 
       - name: Install CR tool
         run: |
+          rm -rf "${CR_TOOL_PATH}"
+          rm -rf "${CR_PACKAGE_PATH}"
+          rm -rf "${CR_INDEX_PATH}"
+          
           mkdir "${CR_TOOL_PATH}"
           mkdir "${CR_PACKAGE_PATH}"
           mkdir "${CR_INDEX_PATH}"
@@ -134,21 +141,21 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.parse-chart.outputs.tagname }}
-          repository: grafana/k8s-monitoring-helm
+          repository: oodle-ai/oodle-k8s-monitoring-helm
           tag_name: ${{ steps.parse-chart.outputs.tagname }}
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           generate_release_notes: true
           files: |
             ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz
 
-      # Note that this creates a release in grafana/helm-charts with a new tag.
-      # The tag name in grafana/helm-charts is <package>-<version>, while the
-      # tag name for grafana/k8s-monitoring-helm is <version>.
+      # Note that this creates a release in oodle-ai/helm-charts with a new tag.
+      # The tag name in oodle-ai/helm-charts is <package>-<version>, while the
+      # tag name for oodle-ai/oodle-k8s-monitoring-helm is <version>.
       - name: Make release on Helm Charts
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.parse-chart.outputs.packagename }}
-          repository: grafana/helm-charts
+          repository: oodle-ai/helm-charts
           tag_name: ${{ steps.parse-chart.outputs.packagename }}
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           body: |

--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.2.1
 appVersion: 2.5.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 sources:
-  - https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring
+  - https://github.com/oodle-ai/k8s-monitoring-helm/tree/main/charts/k8s-monitoring
 maintainers:
   - email: pete.wall@grafana.com
     name: petewall

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
@@ -3,7 +3,8 @@
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]),
+                "X-API-KEY" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .apiKeyName | quote }}]) }
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}
@@ -37,6 +38,36 @@ prometheus.remote_write "metrics_service" {
       sample_age_limit = {{ .queue_config.sample_age_limit | quote }}
     }
   }
+
+{{- if .oodle.host }}
+  endpoint {
+    url = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .oodle.hostKey | quote }}]) + "{{ .oodle.writeEndpoint }}"
+    headers = { "X-API-KEY" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .oodle.apiKeyName | quote }}]) }
+{{ if .writeRelabelConfigRules }}
+{{ .writeRelabelConfigRules | indent 4 }}
+{{- end }}
+{{- if .tls }}
+    tls_config {
+    {{- range $k, $v := .tls }}
+      {{ $k }} = {{ $v | toJson }}
+    {{- end }}
+    }
+{{- end }}
+    send_native_histograms = {{ .sendNativeHistograms }}
+
+    queue_config {
+      capacity = {{ .queue_config.capacity }}
+      min_shards = {{ .queue_config.min_shards }}
+      max_shards = {{ .queue_config.max_shards }}
+      max_samples_per_send = {{ .queue_config.max_samples_per_send }}
+      batch_send_deadline = {{ .queue_config.batch_send_deadline | quote }}
+      min_backoff = {{ .queue_config.min_backoff | quote }}
+      max_backoff = {{ .queue_config.max_backoff | quote }}
+      retry_on_http_429 = {{ .queue_config.retry_on_http_429 }}
+      sample_age_limit = {{ .queue_config.sample_age_limit | quote }}
+    }
+  }
+{{- end }}
 
   wal {
     truncate_frequency = {{ .wal.truncateFrequency | quote }}

--- a/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -18,5 +18,14 @@ data:
 {{- if .tenantId }}
   {{ .tenantIdKey }}: {{ .tenantId | toString | b64enc | quote }}
 {{- end }}
+{{- if .apiKey }}
+  {{ .apiKeyName }}: {{ .apiKey | toString | b64enc | quote }}
+{{- end }}
+{{- if .oodle.host }}
+  {{ .oodle.hostKey }}: {{ .oodle.host | toString | b64enc | quote }}
+{{- end }}
+{{- if .oodle.apiKey }}
+  {{ .oodle.apiKeyName }}: {{ .oodle.apiKey | toString | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -475,6 +475,36 @@
                         "tls": {
                             "type": "object"
                         },
+                        "apiKey": {
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "apiKeyName": {
+                            "type": "string"
+                        },
+                        "oodle": {
+                            "type": "object",
+                            "properties": {
+                                "host": {
+                                    "type": "string"
+                                },
+                                "hostKey": {
+                                    "type": "string"
+                                },
+                                "apiKey": {
+                                    "type": [
+                                        "string"
+                                    ]
+                                },
+                                "apiKeyName": {
+                                    "type": "string"
+                                },
+                                "writeEndpoint": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "wal": {
                             "type": "object",
                             "properties": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -77,6 +77,32 @@ externalServices:
       # @section -- External Services (Prometheus)
       passwordKey: password
 
+    # -- Api key
+    # @section -- External Services (Prometheus)
+    apiKey: ""
+    # -- The key for the api key property in the secret
+    # @section -- External Services (Prometheus)
+    apiKeyName: apiKey
+
+    oodle:
+      # -- Oodle host where metrics will be sent
+      # @section -- External Services (Prometheus)
+      host: ""
+      # -- The key for the oodle host property in the secret
+      # @section -- External Services (Prometheus)
+      hostKey: oodleHost
+
+      # -- Api key for oodle endpoint
+      # @section -- External Services (Prometheus)
+      apiKey: ""
+      # -- The key for the oodle api key property in the secret
+      # @section -- External Services (Prometheus)
+      apiKeyName: oodleApiKey
+
+      # -- Oodle metrics write endpoint
+      # @section -- External Services (Prometheus)
+      writeEndpoint: ""
+
     # Configure the Prometheus Remote Write Queue
     # [docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/#queue_config-block)
     queue_config:


### PR DESCRIPTION
Closes T-1096

### Description of Change
* Support Oodle API key
* Support sending metrics to Oodle as a doublewrite endpoint or the only endpoint to help migration

### Test plan
- [x] Manual test